### PR TITLE
DOM ready compatible with turbolinks 5

### DIFF
--- a/vendor/assets/javascripts/bootstrap-sortable.js
+++ b/vendor/assets/javascripts/bootstrap-sortable.js
@@ -285,5 +285,7 @@
 
     // Initialise on DOM ready
     $($.bootstrapSortable);
+    // DOM ready compatible with turbolinks 5
+    $( document ).on('turbolinks:load', $.bootstrapSortable );
 
 }(jQuery));


### PR DESCRIPTION
The plugin don't work with turbolinks 5 (default in Rails 5) as the DOM ready syntax as changed. This is a fix for compatibility.